### PR TITLE
Add region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 Swirl
 =====
 
-Swirl is an EC2 version agnostic client for EC2 writtin in Ruby. It gets
+Swirl is an EC2 version agnostic client for EC2 written in Ruby. It gets
 out of your way.
 
 The secret is it's simple input extraction and output compacting.  Your
 input parameters and `expand`ed and EC2's (terrible) xml output is
 `compact`ed.
-
 
 Some simple examples:
 
@@ -37,7 +36,7 @@ and
       }
     }
 
-and it's varations are now `compact`ed to:
+and it's variations are now `compact`ed to:
 
   {
     "reservationSet" => {
@@ -46,15 +45,15 @@ and it's varations are now `compact`ed to:
   }
 
 
-Some things worth noteing is that compact ignores Symbols.  This
+Some things worth noting is that compact ignores Symbols.  This
 allows you to pass the params into `call` and use them later
-without affecting the API call (i.e. chain of responsiblity); a
+without affecting the API call (i.e. chain of responsibility); a
 nifty trick we use in (Rack)[http://github.com/rack/rack]
 
 Use
 ---
 
-    ec2 = Swirl::EC2.new
+    ec2 = Swirl::AWS.new(:ec2)
 
     # Describe all instances
     ec2.call "DescribeInstances"
@@ -62,6 +61,8 @@ Use
     # Describe specific instances
     ec2.call "DescribeInstances", "InstanceId" => ["i-38hdk2f", "i-93nndch"]
 
+    # Talk to a different region
+    ec2_asia = Swirl::AWS.new(:ec2, :region => 'ap-southeast-1')
 
 Shell
 ---

--- a/bin/swirl
+++ b/bin/swirl
@@ -7,10 +7,12 @@ require 'optparse'
 interactive = false
 account = "default"
 etc = "#{ENV["HOME"]}/.swirl"
+region = 'us-east-1'
 
 ARGV.options do |o|
   o.on("-a ACCOUT", "Account name (default is default)") {|s| account = s }
   o.on("-c FILE", "Swirl file (default is ~/.swirl)") {|s| etc = s }
+  o.on("-r REGION", "Region (default is us-east-1)") {|s| region = s}
   o.on("-i", "Interactive console") { interactive = true }
   o.on("-h", "--help") { puts o; exit }
   o.parse!
@@ -31,8 +33,9 @@ else
     abort("I don't see the account you're looking for")
   end
 end
+config[:region] = region
 
-c = Swirl::EC2.new config
+c = Swirl::AWS.new(:ec2, config)
 
 # We can now start the interactive session
 # if requested


### PR DESCRIPTION
Optional argument to new allows swirl to connect to regions other than us-east-1.

Service probably needs a tidyup, and could add support to .swirlrc, too.
