### PR TITLE
Fix logging, handle ErrorResponse messages, add ELB/IAM services

### DIFF
--- a/lib/swirl/aws.rb
+++ b/lib/swirl/aws.rb
@@ -92,7 +92,11 @@ module Swirl
         when 200
           response = compact(data)
         when 400...500
-          messages = Array(data["Response"]["Errors"]).map {|_, e| e["Message"] }
+          messages = if data["Response"]
+            Array(data["Response"]["Errors"]).map {|_, e| e["Message"] }
+          elsif data["ErrorResponse"]
+            Array(data["ErrorResponse"]["Error"]["Code"])
+          end
           raise InvalidRequest, messages.join(",")
         else
           msg = "unexpected response #{code} -> #{data.inspect}"

--- a/lib/swirl/aws.rb
+++ b/lib/swirl/aws.rb
@@ -31,7 +31,8 @@ module Swirl
 
     # Default Services
     service :ec2, "https://ec2.amazonaws.com", "2010-11-15"
-
+    service :elb, "https://elasticloadbalancing.amazonaws.com", "2010-07-01"
+    service :iam, "https://iam.amazonaws.com", "2010-05-08"
 
     def initialize(*args)
       opts = args.last.is_a?(Hash) ? args.pop : Hash.new

--- a/test/aws_test.rb
+++ b/test/aws_test.rb
@@ -4,7 +4,7 @@ require 'swirl/aws'
 class AwsTest < Test::Unit::TestCase
 
   test "raises InvalidRequest on ErrorResponse" do
-    e = Swirl::AWS.new(:ec2, :aws_access_key_id => 'AKIA', :aws_secret_access_key => 'secret')
+    e = Swirl::AWS.new(:elb, :aws_access_key_id => 'AKIA', :aws_secret_access_key => 'secret')
     def e.call!(*args, &blk)
       doc = {"ErrorResponse"=>{"Error"=>{"Code"=>"CertificateNotFound", "Type"=>"Sender"}}}
       blk.call [400, doc]

--- a/test/aws_test.rb
+++ b/test/aws_test.rb
@@ -1,0 +1,15 @@
+require 'contest'
+require 'swirl/aws'
+
+class AwsTest < Test::Unit::TestCase
+
+  test "raises InvalidRequest on ErrorResponse" do
+    e = Swirl::AWS.new(:ec2, :aws_access_key_id => 'AKIA', :aws_secret_access_key => 'secret')
+    def e.call!(*args, &blk)
+      doc = {"ErrorResponse"=>{"Error"=>{"Code"=>"CertificateNotFound", "Type"=>"Sender"}}}
+      blk.call [400, doc]
+    end
+    assert_raise(Swirl::InvalidRequest) { e.call "CreateLoadBalancer", {} }
+  end
+
+end


### PR DESCRIPTION
Errors coming back from the ELB service were responding with a different form of error message than the EC2 service. We're now handling both of these error formats.

I also added the ELB/IAM services by default.
